### PR TITLE
Issue 21 - Add option to disable Lazy annotation and write test to cover

### DIFF
--- a/annotations/src/main/java/org/mapstruct/extensions/spring/SpringMapperConfig.java
+++ b/annotations/src/main/java/org/mapstruct/extensions/spring/SpringMapperConfig.java
@@ -37,4 +37,12 @@ public @interface SpringMapperConfig {
      * @return The bean name for the Spring {@link org.springframework.core.convert.ConversionService}.
      */
     String conversionServiceBeanName() default "";
+
+    /**
+     * To set if the Lazy annotation will be added to the
+     * ConversionService's usage in the ConversionServiceAdapter.  Defaults to true.
+     *
+     * @return true to add the Lazy annotation
+     */
+    boolean lazyAnnotatedConversionServiceBean() default true;
 }

--- a/examples/simple-springboot/build.gradle
+++ b/examples/simple-springboot/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.4.0.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.0.Final'
     implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.4.4'
 }

--- a/examples/simple-springboot/src/main/java/org/mapstruct/extensions/spring/example/boot/Start.java
+++ b/examples/simple-springboot/src/main/java/org/mapstruct/extensions/spring/example/boot/Start.java
@@ -1,6 +1,5 @@
 package org.mapstruct.extensions.spring.example.boot;
 
-import org.mapstruct.extensions.spring.converter.ConversionServiceAdapter;
 import org.mapstruct.extensions.spring.example.Car;
 import org.mapstruct.extensions.spring.example.CarDto;
 import org.mapstruct.extensions.spring.example.SeatConfiguration;

--- a/examples/simple-springboot/src/main/java/org/mapstruct/extensions/spring/example/boot/mappers/MapperSpringConfig.java
+++ b/examples/simple-springboot/src/main/java/org/mapstruct/extensions/spring/example/boot/mappers/MapperSpringConfig.java
@@ -1,8 +1,10 @@
 package org.mapstruct.extensions.spring.example.boot.mappers;
 
 import org.mapstruct.MapperConfig;
-import org.mapstruct.extensions.spring.converter.ConversionServiceAdapter;
+import org.mapstruct.extensions.spring.SpringMapperConfig;
+import org.mapstruct.extensions.spring.example.boot.ConversionServiceAdapter;
 
 @MapperConfig(componentModel = "spring", uses = ConversionServiceAdapter.class)
+@SpringMapperConfig(conversionServiceAdapterPackage = "org.mapstruct.extensions.spring.example.boot")
 public interface MapperSpringConfig {
 }

--- a/examples/simple-springboot/src/test/java/org/mapstruct/extensions/spring/example/boot/ContextLoadsWithLazyTest.java
+++ b/examples/simple-springboot/src/test/java/org/mapstruct/extensions/spring/example/boot/ContextLoadsWithLazyTest.java
@@ -1,0 +1,21 @@
+package org.mapstruct.extensions.spring.example.boot;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ContextLoadsWithLazyTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(Start.class));
+
+    @Test
+    public void shouldLoadContext() {
+        this.contextRunner.run(context -> {
+           assertThat(context).hasBean("conversionServiceAdapter");
+        });
+    }
+}

--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterDescriptor.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterDescriptor.java
@@ -10,6 +10,7 @@ public class ConversionServiceAdapterDescriptor {
     private ClassName adapterClassName;
     private String conversionServiceBeanName;
     private List<Pair<TypeName, TypeName>> fromToMappings;
+    private boolean lazyAnnotatedConversionServiceBean;
 
     public ClassName getAdapterClassName() {
         return adapterClassName;
@@ -33,5 +34,13 @@ public class ConversionServiceAdapterDescriptor {
 
     public void setFromToMappings(final List<Pair<TypeName, TypeName>> fromToMappings) {
         this.fromToMappings = fromToMappings;
+    }
+
+    public boolean isLazyAnnotatedConversionServiceBean() {
+        return lazyAnnotatedConversionServiceBean;
+    }
+
+    public void setLazyAnnotatedConversionServiceBean(boolean lazyAnnotatedConversionServiceBean) {
+        this.lazyAnnotatedConversionServiceBean = lazyAnnotatedConversionServiceBean;
     }
 }

--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
@@ -56,7 +56,9 @@ public class ConversionServiceAdapterGenerator {
         if (StringUtils.isNotEmpty(descriptor.getConversionServiceBeanName())) {
             parameterBuilder.addAnnotation(buildQualifierANnotation(descriptor));
         }
-        parameterBuilder.addAnnotation(buildLazyAnnotation());
+        if (Boolean.TRUE.equals(descriptor.isLazyAnnotatedConversionServiceBean())) {
+            parameterBuilder.addAnnotation(buildLazyAnnotation());
+        }
         return parameterBuilder.build();
     }
 

--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConverterMapperProcessor.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConverterMapperProcessor.java
@@ -64,6 +64,7 @@ public class ConverterMapperProcessor extends AbstractProcessor {
     descriptor.setAdapterClassName(
         ClassName.get(adapterPackageAndClass.getLeft(), adapterPackageAndClass.getRight()));
     descriptor.setConversionServiceBeanName(getConversionServiceName(annotations, roundEnv));
+    descriptor.setLazyAnnotatedConversionServiceBean(getLazyAnnotatedConversionServiceBean(annotations, roundEnv));
     annotations.stream()
         .filter(this::isMapperAnnotation)
         .forEach(
@@ -196,6 +197,17 @@ public class ConverterMapperProcessor extends AbstractProcessor {
 
   private SpringMapperConfig toSpringMapperConfig(final Element element) {
     return element.getAnnotation(SpringMapperConfig.class);
+  }
+
+  private boolean getLazyAnnotatedConversionServiceBean(
+          final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+    return annotations.stream()
+            .filter(annotation -> SPRING_MAPPER_CONFIG.contentEquals(annotation.getQualifiedName()))
+            .findFirst()
+            .flatMap(annotation -> findFirstElementAnnotatedWith(roundEnv, annotation))
+            .map(this::toSpringMapperConfig)
+            .map(SpringMapperConfig::lazyAnnotatedConversionServiceBean)
+            .orElse(Boolean.TRUE);
   }
 
   private Optional<? extends TypeMirror> getConverterSupertype(final Element mapper) {

--- a/extensions/src/test/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGeneratorTest.java
+++ b/extensions/src/test/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGeneratorTest.java
@@ -33,6 +33,7 @@ class ConversionServiceAdapterGeneratorTest {
             "ConversionServiceAdapter"));
     descriptor.setFromToMappings(
         singletonList(Pair.of(ClassName.get("test", "Car"), ClassName.get("test", "CarDto"))));
+    descriptor.setLazyAnnotatedConversionServiceBean(true);
     final StringWriter outputWriter = new StringWriter();
 
     // When
@@ -54,6 +55,7 @@ class ConversionServiceAdapterGeneratorTest {
     descriptor.setConversionServiceBeanName("myConversionService");
     descriptor.setFromToMappings(
             singletonList(Pair.of(ClassName.get("test", "Car"), ClassName.get("test", "CarDto"))));
+    descriptor.setLazyAnnotatedConversionServiceBean(true);
     final StringWriter outputWriter = new StringWriter();
 
     // When


### PR DESCRIPTION
Issue 21 - Add option to disable Lazy annotation and write test to cover successful loading of Context in simple-springboot example.

The reason that I added the additional option in the annotation to turn off the use of the Lazy annotation was so that I could write a test case to cover that the context of the sample application wouldn't load to prove that the Lazy annotation was functioning as expected.  However, I couldn't figure out how to do that because I don't know how to override the annotation values in the ApplicationContextRunner.  Maybe someone else has an idea?

If you are happy with just the single additional test and don't want the option to disable the Lazy annotation, let me know and I will remove it and resubmit.