### PR TITLE
Upgrade to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(11))
         }
     }
 

--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
@@ -164,7 +164,7 @@ public class ConversionServiceAdapterGenerator {
   }
 
   private AnnotationSpec buildGeneratedAnnotationSpec() {
-    return AnnotationSpec.builder(ClassName.get("javax.annotation", "Generated"))
+    return AnnotationSpec.builder(ClassName.get("javax.annotation.processing", "Generated"))
         .addMember("value", "$S", ConversionServiceAdapterGenerator.class.getName())
         .addMember("date", "$S", ISO_INSTANT.format(ZonedDateTime.now(clock)))
         .build();


### PR DESCRIPTION
The `Generated` annotation used does not exist beyond, I believe, Java 9.  Which makes this library not work for those beyond Java 9.  Rather than make it work with both, can we just update the minimum supported version to Java 11?