### PR TITLE
Use "compileOnly" scope for Spring dependencies so they won't trigger…

### DIFF
--- a/test-extensions/build.gradle
+++ b/test-extensions/build.gradle
@@ -2,8 +2,8 @@ apply plugin: "maven-publish"
 apply plugin: "signing"
 
 dependencies {
-    implementation libs.spring.core
-    implementation libs.spring.context
+    compileOnly libs.spring.core
+    compileOnly libs.spring.context
     implementation libs.jakarta.annotation
 
     testImplementation libs.mockito


### PR DESCRIPTION
… unnecessary security warnings.

Fixes #97 