### PR TITLE
Store TypeDescriptors as fields in generated ConversionServiceAdapter

### DIFF
--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
@@ -9,6 +9,7 @@ import static org.mapstruct.extensions.spring.converter.TypeNameUtils.rawType;
 import com.squareup.javapoet.*;
 import java.time.Clock;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -51,16 +52,22 @@ public class ConversionServiceAdapterGenerator extends AdapterRelatedGenerator {
       return descriptor.getFromToMappings().stream()
               .flatMap(fromToMapping -> Stream.of(fromToMapping.getSource(), fromToMapping.getTarget()))
               .distinct()
-              .map(typeName -> FieldSpec.builder(TYPE_DESCRIPTOR_CLASS_NAME, fieldName(typeName), PRIVATE, FINAL)
+              .map(typeName -> FieldSpec.builder(TYPE_DESCRIPTOR_CLASS_NAME, fieldName(typeName), PRIVATE, STATIC, FINAL)
                           .initializer(String.format("%s", typeDescriptorFormat(typeName)), typeDescriptorArguments(typeName).toArray()).build())
               .collect(toList());
   }
 
   private String fieldName(TypeName typeName) {
-      return "typeDescriptor_" + typeName.toString()
+      String fieldName = "TYPE_DESCRIPTOR_" + typeName.toString()
               .replace('.', '_')
               .replace('<', '_')
-              .replace('>', '_');
+              .replace('>', '_')
+              .toUpperCase(Locale.ROOT);
+      if (fieldName.lastIndexOf('_') == fieldName.length() - 1) {
+        return fieldName.substring(0, fieldName.length() - 1);
+      } else {
+        return fieldName;
+      }
   }
 
   private static MethodSpec buildConstructorSpec(

--- a/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
+++ b/extensions/src/main/java/org/mapstruct/extensions/spring/converter/ConversionServiceAdapterGenerator.java
@@ -62,6 +62,7 @@ public class ConversionServiceAdapterGenerator extends AdapterRelatedGenerator {
               .replace('.', '_')
               .replace('<', '_')
               .replace('>', '_')
+              .replace("[]", "_ARRAY")
               .toUpperCase(Locale.ROOT);
       if (fieldName.lastIndexOf('_') == fieldName.length() - 1) {
         return fieldName.substring(0, fieldName.length() - 1);

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava8Generated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava8Generated.java
@@ -15,15 +15,15 @@ import test.CarDto;
     date = "2020-03-29T15:21:34.236Z")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
@@ -31,10 +31,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava8Generated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava8Generated.java
@@ -17,16 +17,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava9PlusGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava9PlusGenerated.java
@@ -15,15 +15,15 @@ import test.CarDto;
     date = "2020-03-29T15:21:34.236Z")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
@@ -31,10 +31,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava9PlusGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanJava9PlusGenerated.java
@@ -17,16 +17,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanNoGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanNoGenerated.java
@@ -11,15 +11,15 @@ import test.CarDto;
 
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
@@ -27,10 +27,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterCustomBeanNoGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterCustomBeanNoGenerated.java
@@ -13,16 +13,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   public ConversionServiceAdapter(
           @Qualifier("myConversionService") @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava8Generated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava8Generated.java
@@ -14,26 +14,25 @@ import test.CarDto;
     date = "2020-03-29T15:21:34.236Z")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
-
 
   public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava8Generated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava8Generated.java
@@ -16,15 +16,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
+
   public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava8GeneratedNoDate.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava8GeneratedNoDate.java
@@ -14,15 +14,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
-  public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
+  public ConversionServiceAdapter(
+          @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava8GeneratedNoDate.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava8GeneratedNoDate.java
@@ -12,15 +12,15 @@ import test.CarDto;
 @Generated("org.mapstruct.extensions.spring.converter.ConversionServiceAdapterGenerator")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Lazy final ConversionService conversionService) {
@@ -28,10 +28,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGenerated.java
@@ -14,15 +14,15 @@ import test.CarDto;
     date = "2020-03-29T15:21:34.236Z")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Lazy final ConversionService conversionService) {
@@ -30,10 +30,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGenerated.java
@@ -16,15 +16,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
-  public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
+  public ConversionServiceAdapter(
+          @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGeneratedNoDate.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGeneratedNoDate.java
@@ -14,15 +14,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
-  public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
+  public ConversionServiceAdapter(
+          @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGeneratedNoDate.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterJava9PlusGeneratedNoDate.java
@@ -12,15 +12,15 @@ import test.CarDto;
 @Generated("org.mapstruct.extensions.spring.converter.ConversionServiceAdapterGenerator")
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Lazy final ConversionService conversionService) {
@@ -28,10 +28,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterNoGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterNoGenerated.java
@@ -12,15 +12,24 @@ import test.CarDto;
 public class ConversionServiceAdapter {
   private final ConversionService conversionService;
 
-  public ConversionServiceAdapter(@Lazy final ConversionService conversionService) {
+  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
+
+  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
+  public ConversionServiceAdapter(
+          @Lazy final ConversionService conversionService) {
     this.conversionService = conversionService;
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, TypeDescriptor.valueOf(Car.class), TypeDescriptor.valueOf(CarDto.class));
+    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class)), TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class)));
+    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
   }
 }

--- a/extensions/src/test/resources/ConversionServiceAdapterNoGenerated.java
+++ b/extensions/src/test/resources/ConversionServiceAdapterNoGenerated.java
@@ -10,15 +10,15 @@ import test.CarDto;
 
 @Component
 public class ConversionServiceAdapter {
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CAR = TypeDescriptor.valueOf(Car.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_TEST_CARDTO = TypeDescriptor.valueOf(CarDto.class);
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
+
+  private static final TypeDescriptor TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
+
   private final ConversionService conversionService;
-
-  private final TypeDescriptor typeDescriptor_test_Car = TypeDescriptor.valueOf(Car.class);
-
-  private final TypeDescriptor typeDescriptor_test_CarDto = TypeDescriptor.valueOf(CarDto.class);
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_Car_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(Car.class));
-
-  private final TypeDescriptor typeDescriptor_java_util_List_test_CarDto_ = TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(CarDto.class));
 
   public ConversionServiceAdapter(
           @Lazy final ConversionService conversionService) {
@@ -26,10 +26,10 @@ public class ConversionServiceAdapter {
   }
 
   public CarDto toDto(final Car source) {
-    return (CarDto) conversionService.convert(source, typeDescriptor_test_Car, typeDescriptor_test_CarDto);
+    return (CarDto) conversionService.convert(source, TYPE_DESCRIPTOR_TEST_CAR, TYPE_DESCRIPTOR_TEST_CARDTO);
   }
 
   public List<CarDto> mapListOfCarToListOfCarDto(final List<Car> source) {
-    return (List<CarDto>) conversionService.convert(source, typeDescriptor_java_util_List_test_Car_, typeDescriptor_java_util_List_test_CarDto_);
+    return (List<CarDto>) conversionService.convert(source, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CAR, TYPE_DESCRIPTOR_JAVA_UTIL_LIST_TEST_CARDTO);
   }
 }


### PR DESCRIPTION
This should reduce garbage generated by creating new TypeDescriptor instances for every conversion call.